### PR TITLE
Fix for MiniAOD->Bambu

### DIFF
--- a/Configuration/python/BambuProdMiniAodsim.py
+++ b/Configuration/python/BambuProdMiniAodsim.py
@@ -8,8 +8,7 @@ process = cms.Process('FILEFI')
 
 # say how many events to process (-1 means no limit)
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(100)
-  #input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(100)
 )
 
 #>> input source
@@ -77,32 +76,21 @@ process.load('MitProd.TreeFiller.FastJetCorrection_cff')
 from MitProd.TreeFiller.pfCHSFromPacked_cff import pfCHSSequence
 process.load('MitProd.TreeFiller.pfCHSFromPacked_cff')
 
-# Load tracking off packedCandidates
-from PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi import unpackedTracksAndVertices
-process.load('PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi')
-
 # Load btagging
 from MitProd.TreeFiller.utils.setupBTag import setupBTag
 ak4PFBTagSequence = setupBTag(process, 'ak4PFJets', 'AKt4PF', candidates = 'packedPFCandidates', primaryVertex = 'offlineSlimmedPrimaryVertices', muons = 'slimmedMuons', electrons = 'slimmedElectrons')
-
-from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import inclusiveVertexing,inclusiveCandidateVertexing
-process.load('RecoVertex/AdaptiveVertexFinder/inclusiveVertexing_cff')
-
 
 #> Setup jet corrections
 process.load('JetMETCorrections.Configuration.JetCorrectionServices_cff')
 
 #> The bambu reco sequence
 recoSequence = cms.Sequence(
-  unpackedTracksAndVertices *
   pfCHSSequence *
   l1FastJetSequence *
   l1FastJetSequenceCHS *
   ak4PFJets *
   ak8PFJets *
-  ak4PFBTagSequence *
-  inclusiveVertexing *
-  inclusiveCandidateVertexing
+  ak4PFBTagSequence
 )
 
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#

--- a/TreeFiller/interface/AssociationMaps.h
+++ b/TreeFiller/interface/AssociationMaps.h
@@ -49,6 +49,7 @@
 #include "MitAna/DataTree/interface/VertexFwd.h"
 #include "MitAna/DataTree/interface/PFCandidateFwd.h"
 #include "MitAna/DataTree/interface/PhotonFwd.h"
+#include "MitAna/DataTree/interface/JetFwd.h"
 #include "MitAna/DataTree/interface/CaloJetFwd.h"
 #include "MitAna/DataTree/interface/JPTJetFwd.h"
 #include "MitAna/DataTree/interface/PFJetFwd.h"
@@ -82,6 +83,7 @@ namespace mithep
   typedef AssociationMap<const edm::Ptr<reco::Photon>,      mithep::Photon*>        PhotonMap;
   typedef AssociationMap<const edm::Ptr<reco::BaseTau>,     mithep::PFTau*>         PFTauMap;
   typedef AssociationMap<const reco::CandidatePtr,          mithep::PFCandidate*>   PFCandidateMap;
+  typedef AssociationMap<const edm::Ptr<reco::Jet>,         mithep::Jet*>           JetMap;
   typedef AssociationMap<const edm::Ptr<reco::Jet>,         mithep::CaloJet*>       CaloJetMap;
   typedef AssociationMap<const edm::Ptr<reco::Jet>,         mithep::JPTJet*>        JPTJetMap;
   typedef AssociationMap<const edm::Ptr<reco::Jet>,         mithep::PFJet*>         PFJetMap;

--- a/TreeFiller/interface/FillerCaloJets.h
+++ b/TreeFiller/interface/FillerCaloJets.h
@@ -17,14 +17,15 @@
 
 namespace mithep {
 
-  class FillerCaloJets : public FillerJets<mithep::CaloJet> {
+  class FillerCaloJets : public FillerJets {
   public:
     FillerCaloJets(edm::ParameterSet const&, edm::ConsumesCollector&, ObjectService*, char const* name, bool active = true);
     ~FillerCaloJets();
 
     void PrepareLinks() override;
+    mithep::Jet* AddNew() override { return static_cast<mithep::CaloJetArr*>(jets_)->AddNew(); }
     void PrepareSpecific(edm::Event const&, edm::EventSetup const&) override;
-    void FillSpecific(mithep::CaloJet&, reco::JetBaseRef const&) override;
+    void FillSpecific(mithep::Jet&, reco::JetBaseRef const&) override;
     void ResolveLinks(edm::Event const&, edm::EventSetup const&) override;
 
   private:

--- a/TreeFiller/interface/FillerJPTJets.h
+++ b/TreeFiller/interface/FillerJPTJets.h
@@ -15,13 +15,14 @@
 
 namespace mithep {
 
-  class FillerJPTJets : public FillerJets<mithep::JPTJet> {  
+  class FillerJPTJets : public FillerJets {
   public:
     FillerJPTJets(edm::ParameterSet const&, edm::ConsumesCollector&, ObjectService*, char const* name, bool active = true);
     ~FillerJPTJets();
 
     void PrepareLinks() override;
-    void FillSpecific(mithep::JPTJet&, reco::JetBaseRef const&) override;
+    mithep::Jet* AddNew() override { return static_cast<mithep::JPTJetArr*>(jets_)->AddNew(); }
+    void FillSpecific(mithep::Jet&, reco::JetBaseRef const&) override;
     void ResolveLinks(edm::Event const&, edm::EventSetup const&) override;
   
   private:

--- a/TreeFiller/interface/FillerJets.h
+++ b/TreeFiller/interface/FillerJets.h
@@ -6,15 +6,10 @@
 // Authors: Y.Iiyama
 //--------------------------------------------------------------------------------------------------
 
-#ifndef FILLERJETS_INSTANCE
-#warning This header is protected from accidental inclusions.
-#abort // there is no such preprocessor - will therefore abort.
-#endif
-
 #ifndef MITPROD_TREEFILLER_FILLERJETS_H
 #define MITPROD_TREEFILLER_FILLERJETS_H
 
-#include "MitProd/TreeFiller/interface/AssociationMap.h"
+#include "MitProd/TreeFiller/interface/AssociationMaps.h"
 #include "MitProd/TreeFiller/interface/BaseFiller.h"
 #include "MitProd/ObjectService/interface/ObjectService.h"
 #include "MitAna/DataTree/interface/Jet.h"
@@ -24,26 +19,23 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/BTauReco/interface/JetTag.h"
 #include "SimDataFormats/JetMatching/interface/JetMatchedPartons.h"
-#include "SimDataFormats/JetMatching/interface/MatchedPartons.h"
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
 
 namespace mithep {
 
-  template<class MITJET>
   class FillerJets : public BaseFiller {  
   public:
     FillerJets(edm::ParameterSet const&, edm::ConsumesCollector&, ObjectService*, char const* name, bool active = true);
     ~FillerJets();
 
     void BookDataBlock(TreeWriter&) override;
-    virtual void BookAdditional(TreeWriter&) {}
     void FillDataBlock(edm::Event const&, edm::EventSetup const&) override;
+    void FillPostRunBlock(edm::Run const&, edm::EventSetup const&) override;
+    virtual mithep::Jet* AddNew() = 0;
+    virtual void BookAdditional(TreeWriter&) {}
     virtual void PrepareSpecific(edm::Event const&, edm::EventSetup const&) {}
-    virtual void FillSpecific(MITJET&, reco::JetBaseRef const&) {}
-
-    typedef mithep::AssociationMap<edm::Ptr<reco::Jet>, MITJET*> JetAssociationMap;
-    typedef mithep::Array<MITJET> ProductArray;
-  
+    virtual void FillSpecific(mithep::Jet&, reco::JetBaseRef const&) {}
+ 
   protected:
     enum FlavorMatchingDef {
       kAlgorithmic,
@@ -78,229 +70,10 @@ namespace mithep {
     JetCorrector const* L2Corrector_;
     JetCorrector const* L3Corrector_;
 
-    JetAssociationMap* jetMap_;      //export map
-    ProductArray* jets_;        //array of Jets
+    JetMap*         jetMap_;      //export map
+    BaseCollection* jets_;        //array of Jets
   };
 
-}
-
-template<class MITJET>
-mithep::FillerJets<MITJET>::FillerJets(edm::ParameterSet const& cfg, edm::ConsumesCollector& collector, ObjectService* os, char const* name, bool active/* = true*/) :
-  BaseFiller(cfg, os, name, active),
-  flavorMatchingActive_(cfg.getUntrackedParameter<bool>("flavorMatchingActive", true)),
-  bTaggingActive_(cfg.getUntrackedParameter<bool>("bTaggingActive", true)),
-  jetToVertexActive_(cfg.getUntrackedParameter<bool>("jetToVertexActive", true)),
-  jetCorrectionsActive_(cfg.getUntrackedParameter<bool>("jetCorrectionsActive", true)),
-  edmToken_(GetToken<reco::JetView>(collector, cfg, "edmName")),
-  jetToVertexAlphaToken_(GetToken<std::vector<double> >(collector, cfg, "jetToVertexAlphaName", jetToVertexActive_)), //jetToVertexAlpha
-  jetToVertexBetaToken_(GetToken<std::vector<double> >(collector, cfg, "jetToVertexBetaName", jetToVertexActive_)), //jetToVertexBetaName
-  flavorMatchingByReferenceToken_(GetToken<reco::JetMatchedPartonsCollection>(collector, cfg, "flavorMatchingByReferenceName", flavorMatchingActive_)), //srcByReference
-  bJetTagsToken_{},
-  rhoToken_(GetToken<double>(collector, cfg, "rhoName", jetCorrectionsActive_)),
-  mitName_(cfg.getUntrackedParameter<string>("mitName")),
-  L2JetCorrectorName_(cfg.getUntrackedParameter<std::string>("L2JetCorrectorName", "L2JetCorrectorName")),
-  L3JetCorrectorName_(cfg.getUntrackedParameter<std::string>("L3JetCorrectorName", "L3JetCorrectorName")),
-  jetMapName_(cfg.getUntrackedParameter<string>("jetMapName")),
-  flavorMatchingDefinition_{},
-  rho_(0.),
-  L2Corrector_(0),
-  L3Corrector_(0),
-  jetMap_(new JetAssociationMap),
-  jets_(new ProductArray(16))
-{
-  for (unsigned iA = 0; iA != mithep::Jet::nBTagAlgos; ++iA) {
-    std::string paramName(mithep::Jet::BTagAlgoName(iA) + std::string("BJetTagsName"));
-    bJetTagsToken_[iA] = GetToken<reco::JetTagCollection>(collector, cfg, paramName, false);
-  }
-
-  std::string defName(cfg.getUntrackedParameter<std::string>("flavorMatchingDefinition", "Algorithmic"));
-  if (defName == "Algorithmic")
-    flavorMatchingDefinition_ = kAlgorithmic;
-  else if (defName == "Physics")
-    flavorMatchingDefinition_ = kPhysics;
-  else
-    throw edm::Exception(edm::errors::Configuration, "FillerJets::Ctor")
-      << "Invalid flavor matching definition";
-}
-
-template<class MITJET>
-mithep::FillerJets<MITJET>::~FillerJets()
-{
-  delete jetMap_;
-  delete jets_;
-}
-
-template<class MITJET>
-void
-mithep::FillerJets<MITJET>::BookDataBlock(TreeWriter& tws)
-{
-  tws.AddBranch(mitName_, &jets_);
-  OS()->add(jets_, mitName_);
-
-  if (!jetMapName_.empty()) {
-    jetMap_->SetBrName(mitName_);
-    OS()->add(jetMap_, jetMapName_);
-  }
-
-  BookAdditional(tws);
-}
-
-template<class MITJET>
-void
-mithep::FillerJets<MITJET>::FillDataBlock(edm::Event const& event, edm::EventSetup const& setup)
-{
-  jets_->Delete();
-  jetMap_->Reset();
-  
-  edm::Handle<reco::JetView> hJetsH;
-  GetProduct(edmToken_, hJetsH, event);
-  auto& inJets = *hJetsH;
-  
-  // handles for jet flavour matching 
-  reco::JetMatchedPartonsCollection const* matchedPartons = 0;
-  if (flavorMatchingActive_) {
-    edm::Handle<reco::JetMatchedPartonsCollection> hMatchH;
-    GetProduct(flavorMatchingByReferenceToken_, hMatchH, event);
-    matchedPartons = hMatchH.product();
-  }
-
-  reco::JetTagCollection const* bJetTags[mithep::Jet::nBTagAlgos] = {};
-
-  if (bTaggingActive_)
-    initBJetTags(event, bJetTags);
-
-  if (jetCorrectionsActive_)
-    initCorrections(event, setup);
-  
-  std::vector<double> const* jvAlpha = 0; 
-  std::vector<double> const* jvBeta = 0;
-  if (jetToVertexActive_) {
-    edm::Handle<std::vector<double>> jvAlphaH;
-    edm::Handle<std::vector<double>> jvBetaH;
-    GetProduct(jetToVertexAlphaToken_, jvAlphaH, event); 
-    GetProduct(jetToVertexBetaToken_, jvBetaH, event);  
-    jvAlpha = jvAlphaH.product();
-    jvBeta = jvBetaH.product();
-  }
-
-  PrepareSpecific(event, setup);
-
-  // loop through all jets
-  for (unsigned iJ = 0; iJ != inJets.size(); ++iJ) {
-    auto& inJet = inJets.at(iJ);
-    auto&& baseRef = inJets.refAt(iJ);
-    
-    auto* outJet = jets_->AddNew();
-
-    jetMap_->Add(inJets.ptrAt(iJ), outJet);
-
-    // for pat::Jets, p4() is already corrected - fixed in FillSpecific
-    outJet->SetRawPtEtaPhiM(inJet.p4().pt(), inJet.p4().eta(), inJet.p4().phi(), inJet.p4().mass());
-
-    //fill jet moments
-    outJet->SetSigmaEta(TMath::Sqrt(inJet.etaetaMoment()));
-    outJet->SetSigmaPhi(TMath::Sqrt(inJet.phiphiMoment()));
-
-    //fill jet area
-    outJet->SetJetArea(inJet.jetArea());
-
-    FillSpecific(*outJet, baseRef);
-
-    if (jetToVertexActive_) {
-      //compute alpha and beta parameter for jets
-      outJet->SetAlpha(jvAlpha->at(iJ));
-      outJet->SetBeta(jvBeta->at(iJ));      
-    }
-
-    if (bTaggingActive_)
-      setBJetTags(*outJet, baseRef, bJetTags);
-
-    if (jetCorrectionsActive_)
-      setCorrections(*outJet, inJet);
-
-    // get the Monte Carlo flavour matching information
-    if (flavorMatchingActive_) {
-      auto&& matchedParton = (*matchedPartons)[matchedPartons->key(iJ)];
-
-      outJet->SetMatchedMCFlavor(0);      
-      switch (flavorMatchingDefinition_) {
-      case kAlgorithmic:
-        if (matchedParton.algoDefinitionParton().isNonnull())
-          outJet->SetMatchedMCFlavor(matchedParton.algoDefinitionParton()->pdgId());
-        break;
-
-      case kPhysics:
-        if (matchedParton.physicsDefinitionParton().isNonnull())
-          outJet->SetMatchedMCFlavor(matchedParton.physicsDefinitionParton()->pdgId());
-        break;
-
-      default:
-        break;
-      }
-    }
-  }
-
-  jets_->Trim();
-}
-
-template<class MITJET>
-void
-mithep::FillerJets<MITJET>::initBJetTags(edm::Event const& event,
-                                         reco::JetTagCollection const* bJetTags[mithep::Jet::nBTagAlgos])
-{
-  for (unsigned iT = 0; iT != mithep::Jet::nBTagAlgos; ++iT) {
-    edm::Handle<reco::JetTagCollection> hBJetTags;
-    if (GetProductSafe(bJetTagsToken_[iT], hBJetTags, event))
-      bJetTags[iT] = hBJetTags.product();
-  }
-}
-
-template<class MITJET>
-void
-mithep::FillerJets<MITJET>::setBJetTags(mithep::Jet& outJet, reco::JetBaseRef const& baseRef,
-                                        reco::JetTagCollection const* bJetTags[mithep::Jet::nBTagAlgos]) const
-{
-  for (unsigned iT = 0; iT != mithep::Jet::nBTagAlgos; ++iT) {
-    if (bJetTags[iT])
-      outJet.SetBJetTagsDisc((*bJetTags[iT])[baseRef], iT);
-  }
-}
-
-template<class MITJET>
-void
-mithep::FillerJets<MITJET>::initCorrections(edm::Event const& event, edm::EventSetup const& setup)
-{
-  edm::Handle<double> hRho;
-  GetProduct(rhoToken_, hRho, event);
-  rho_ = *hRho;
-
-  L2Corrector_ = JetCorrector::getJetCorrector(L2JetCorrectorName_, setup);
-  L3Corrector_ = JetCorrector::getJetCorrector(L3JetCorrectorName_, setup);
-}
-
-template<class MITJET>
-void
-mithep::FillerJets<MITJET>::setCorrections(mithep::Jet& outJet, reco::Jet const&)
-{
-  // jet corrections
-
-  double L1Scale = std::max((outJet.RawMom().pt() - rho_ * outJet.JetArea()) / outJet.RawMom().pt(), 0.);
-  outJet.SetL1OffsetCorrectionScale(L1Scale);
-  outJet.EnableCorrection(mithep::Jet::L1);
-
-  FourVector p4(outJet.RawMom().Px(), outJet.RawMom().Py(), outJet.RawMom().Pz(), outJet.RawMom().E());
-
-  p4 *= L1Scale;
-
-  double L2Scale = L2Corrector_->correction(p4);
-  outJet.SetL2RelativeCorrectionScale(L2Scale);
-  outJet.EnableCorrection(mithep::Jet::L2);
-
-  p4 *= L2Scale;
-
-  double L3Scale = L3Corrector_->correction(p4);
-  outJet.SetL3AbsoluteCorrectionScale(L3Scale);
-  outJet.EnableCorrection(mithep::Jet::L3);
 }
 
 #endif

--- a/TreeFiller/interface/FillerPFJets.h
+++ b/TreeFiller/interface/FillerPFJets.h
@@ -6,12 +6,6 @@
 // Authors: C.Loizides, Y.Iiyama
 //--------------------------------------------------------------------------------------------------
 
-// reverse header protection - this file should be included only by FillerPFJets.cc
-#ifndef FILLERPFJETS_INSTANCE
-#warning This header is protected from accidental inclusions.
-#abort // there is no such preprocessor - will therefore abort.
-#endif
-
 #ifndef MITPROD_TREEFILLER_FILLERPFJETS_H
 #define MITPROD_TREEFILLER_FILLERPFJETS_H
 
@@ -19,26 +13,34 @@
 #include "MitProd/TreeFiller/interface/AssociationMaps.h"
 #include "MitAna/DataTree/interface/PFJetCol.h"
 
-#include "DataFormats/JetReco/interface/PFJet.h"
+namespace reco {
+  class PFJet;
+}
+namespace pat {
+  class Jet;
+}
 
 namespace mithep {
 
-  template<class PFJET>
-  class FillerPFJets : public FillerJets<mithep::PFJet> {
+  class FillerPFJets : public FillerJets {
   public:
     FillerPFJets(edm::ParameterSet const&, edm::ConsumesCollector&, ObjectService*, char const*, bool = true);
     ~FillerPFJets();
 
     void PrepareLinks() override;
-    void FillSpecific(mithep::PFJet&, reco::JetBaseRef const&) override;
+    mithep::Jet* AddNew() override { return static_cast<mithep::PFJetArr*>(jets_)->AddNew(); }
+    void FillSpecific(mithep::Jet&, reco::JetBaseRef const&) override;
     void ResolveLinks(edm::Event const&, edm::EventSetup const&) override;
 
   private:
-    void fillPFJetVariables(mithep::PFJet&, PFJET const&);
+    void fillPFJetVariables(mithep::PFJet&, reco::PFJet const&);
+    void fillPATJetVariables(mithep::PFJet&, pat::Jet const&);
     void initBJetTags(edm::Event const&, reco::JetTagCollection const* [mithep::Jet::nBTagAlgos]) override;
     void setBJetTags(mithep::Jet&, reco::JetBaseRef const&, reco::JetTagCollection const* [mithep::Jet::nBTagAlgos]) const override;
     void initCorrections(edm::Event const&, edm::EventSetup const&) override;
     void setCorrections(mithep::Jet&, reco::Jet const&) override;
+
+    bool fillFromPAT_;
 
     std::string bJetTagsName_[mithep::Jet::nBTagAlgos];
 

--- a/TreeFiller/interface/FillerPackedPFCandidates.h
+++ b/TreeFiller/interface/FillerPackedPFCandidates.h
@@ -22,6 +22,7 @@ namespace mithep
     ~FillerPackedPFCandidates();
 
     void BookDataBlock(TreeWriter &) override;
+    void PrepareLinks() override;
     void FillDataBlock(edm::Event const&, edm::EventSetup const&) override;
     void ResolveLinks(edm::Event const&, edm::EventSetup const&) override;
 
@@ -34,6 +35,7 @@ namespace mithep
     std::string                 electronMapName_;
     std::string                 muonMapName_;
     std::string                 photonMapName_;
+    std::string                 trackMapName_;
 
     mithep::PFCandidateMap*     pfCandMap_;                //exported map
     mithep::PFCandidateMap*     pfNoPileupCandMap_;        //exported map for pf no pileup
@@ -43,6 +45,7 @@ namespace mithep
     mithep::CandidateMap const* electronMap_;
     mithep::CandidateMap const* muonMap_;
     mithep::CandidateMap const* photonMap_;
+    mithep::CandidateMap const* trackMap_;
   };
 }
 #endif

--- a/TreeFiller/interface/FillerTrackJets.h
+++ b/TreeFiller/interface/FillerTrackJets.h
@@ -15,12 +15,13 @@
 
 namespace mithep {
 
-  class FillerTrackJets : public FillerJets<mithep::TrackJet> {  
+  class FillerTrackJets : public FillerJets {  
   public:
     FillerTrackJets(edm::ParameterSet const&, edm::ConsumesCollector&, ObjectService*, char const* name, bool active = true);
     ~FillerTrackJets();
 
     void PrepareLinks() override;
+    mithep::Jet* AddNew() override { return static_cast<mithep::TrackJetArr*>(jets_)->AddNew(); }
     void ResolveLinks(edm::Event const&, edm::EventSetup const&) override;
 
   private:

--- a/TreeFiller/interface/FillerTracks.h
+++ b/TreeFiller/interface/FillerTracks.h
@@ -19,6 +19,7 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 class TrackAssociatorParameters;
 class TrackDetectorAssociator;
@@ -27,59 +28,63 @@ class MagneticField;
 namespace mithep 
 {
   class FillerTracks : public BaseFiller {  
-    public:
-      FillerTracks(const edm::ParameterSet &cfg, edm::ConsumesCollector&, ObjectService*, const char *name, bool active=1);
-      ~FillerTracks();
+  public:
+    FillerTracks(edm::ParameterSet const&, edm::ConsumesCollector&, ObjectService*, char const* name, bool active = true);
+    ~FillerTracks();
 
-      void BookDataBlock(TreeWriter&) override;
-      void PrepareLinks() override;
-      void FillDataBlock(const edm::Event&, const edm::EventSetup&) override;
-      void ResolveLinks(const edm::Event&, const edm::EventSetup&) override;
+    void BookDataBlock(TreeWriter&) override;
+    void PrepareLinks() override;
+    void FillDataBlock(const edm::Event&, const edm::EventSetup&) override;
+    void ResolveLinks(const edm::Event&, const edm::EventSetup&) override;
 
-    protected:
-      static void InitLayerMap(std::map<uint32_t, mithep::Track::EHitLayer>&);
-      mithep::Track* ProduceTrack(reco::Track const&);
-      void EcalAssoc(mithep::Track*, reco::Track const&, edm::Event const&, edm::EventSetup const&, TrackDetectorAssociator&, MagneticField const&);
+  protected:
+    static void InitLayerMap(std::map<uint32_t, mithep::Track::EHitLayer>&);
+    mithep::Track* ProduceTrack(reco::Track const&);
+    void EcalAssoc(mithep::Track*, reco::Track const&, edm::Event const&, edm::EventSetup const&, TrackDetectorAssociator&, MagneticField const&);
 
-      typedef edm::View<reco::Track> TrackView;
-      typedef edm::View<reco::GsfElectron> ElectronView;
-      typedef edm::View<reco::Muon> MuonView;
+    typedef edm::View<reco::Track> TrackView;
+    typedef edm::View<reco::GsfElectron> ElectronView;
+    typedef edm::View<reco::Muon> MuonView;
+    typedef edm::View<pat::PackedCandidate> PackedCandView;
 
-      enum SourceType {
-        kTracks,
-        kElectronGsf,
-        kElectronCtf,
-        kMuonInner,
-        kMuonStandalone,
-        kMuonCombined,
-        kMuonTPFMS,
-        kMuonPicky,
-        kMuonDYT,
-        nSourceTypes
-      };        
+    enum SourceType {
+      kTracks,
+      kElectronGsf,
+      kElectronCtf,
+      kMuonInner,
+      kMuonStandalone,
+      kMuonCombined,
+      kMuonTPFMS,
+      kMuonPicky,
+      kMuonDYT,
+      kPackedCandidates,
+      nSourceTypes
+    };        
 
-      SourceType                          sourceType_;                  //what we are filling tracks from
-      bool                                ecalAssocActive_;             //do track-ecal associations
-      edm::EDGetTokenT<TrackView> edmToken_;              //edm name of tracks coll
-      edm::EDGetTokenT<ElectronView> edmElectronToken_;//when filling from embedded tracks in PAT electron
-      edm::EDGetTokenT<MuonView> edmMuonToken_;           //when filling from embedded tracks in PAT muon
-      edm::EDGetTokenT<reco::RecoToSimCollection> edmSimAssocToken_;    //edm name of sim assoc map
-      std::string                         mitName_;                     //mit name of Tracks
-      std::string                         trackingMapName_;             //name of imp. map wrt sim
-      std::string                         barrelSuperClusterIdMapName_; //name of barrel sc id map
-      std::string                         endcapSuperClusterIdMapName_; //name of endcap sc id map
-      std::string                         trackMapName_;                //name of export map
-      const mithep::TrackingParticleMap*  trackingMap_;                 //map wrt sim. particles
-      const mithep::SuperClusterIdMap*    barrelSuperClusterIdMap_;     //barrel sc id map
-      const mithep::SuperClusterIdMap*    endcapSuperClusterIdMap_;     //endcap sc id map
-      mithep::TrackArr*                   tracks_;                      //array of tracks
-      mithep::HitPatternReader            hitReader_;                   //hit pattern reader
-      TrackAssociatorParameters*          assocParams_;                 //track associator params
+    SourceType                          sourceType_;                  //what we are filling tracks from
+    bool                                ecalAssocActive_;             //do track-ecal associations
+    edm::EDGetTokenT<TrackView> edmToken_;                            //edm token of tracks coll
+    edm::EDGetTokenT<ElectronView> edmElectronToken_;                 //when filling from embedded tracks in PAT electron
+    edm::EDGetTokenT<MuonView> edmMuonToken_;                         //when filling from embedded tracks in PAT muon
+    edm::EDGetTokenT<PackedCandView> edmPackedCandToken_;             //when filling from miniAOD PF candidates
+    edm::EDGetTokenT<reco::RecoToSimCollection> edmSimAssocToken_;    //edm token of sim assoc map
+    std::string                         mitName_;                     //mit name of Tracks
+    std::string                         trackingMapName_;             //name of imp. map wrt sim
+    std::string                         barrelSuperClusterIdMapName_; //name of barrel sc id map
+    std::string                         endcapSuperClusterIdMapName_; //name of endcap sc id map
+    std::string                         trackMapName_;                //name of export map
+    const mithep::TrackingParticleMap*  trackingMap_;                 //map wrt sim. particles
+    const mithep::SuperClusterIdMap*    barrelSuperClusterIdMap_;     //barrel sc id map
+    const mithep::SuperClusterIdMap*    endcapSuperClusterIdMap_;     //endcap sc id map
+    mithep::TrackArr*                   tracks_;                      //array of tracks
+    mithep::HitPatternReader            hitReader_;                   //hit pattern reader
+    TrackAssociatorParameters*          assocParams_;                 //track associator params
 
-    private:
-      mithep::TrackMap*                   trackMap_;                    //map wrt tracks
-      mithep::ElectronTrackMap*           eleTrackMap_;                 //map GsfElectron -> GsfTrack (when filling from PAT)
-      mithep::MuonTrackMap*               muTrackMap_;                  //map Muon -> Track (when filling from PAT)
+  private:
+    mithep::TrackMap*                   trackMap_;                    //map wrt tracks
+    mithep::ElectronTrackMap*           eleTrackMap_;                 //map GsfElectron -> GsfTrack (when filling from PAT)
+    mithep::MuonTrackMap*               muTrackMap_;                  //map Muon -> Track (when filling from PAT)
+    mithep::CandidateMap*               pfTrackMap_;                   //map reco::Candidate -> Track (when filling from PAT)
   };
 }
 #endif

--- a/TreeFiller/interface/FillerVertexes.h
+++ b/TreeFiller/interface/FillerVertexes.h
@@ -1,6 +1,4 @@
 //--------------------------------------------------------------------------------------------------
-// $Id: FillerVertexes.h,v 1.8 2009/12/11 17:45:38 bendavid Exp $
-//
 // FillerVertexes
 //
 // Implementation of a filler to fill EDM reco:Vertex into our mithep::Vertex data structure.
@@ -16,6 +14,7 @@
 #include "MitProd/TreeFiller/interface/BaseFiller.h"
 
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 namespace mithep 
 {
@@ -25,10 +24,13 @@ namespace mithep
       FillerVertexes(const edm::ParameterSet &cfg, edm::ConsumesCollector&, ObjectService*, const char *name, bool active=1);
       ~FillerVertexes();
 
-      void                     BookDataBlock(TreeWriter &tws);
-      void                     FillDataBlock(const edm::Event &e, const edm::EventSetup &es);
+      void BookDataBlock(TreeWriter &tws);
+      void PrepareLinks();
+      void FillDataBlock(const edm::Event &e, const edm::EventSetup &es);
+      void ResolveLinks(const edm::Event &e, const edm::EventSetup &es);
   
     private:
+      bool                     trkAssocByPacked_; // associate to tracks extracted from pat::PackedCandidates
       edm::EDGetTokenT<reco::VertexCollection> edmToken_;        //edm name of Vertex collection
       std::string              mitName_;        //mit name of Vertices
       std::string              trackMapName_;   //name of imported map wrt trk trks
@@ -36,6 +38,7 @@ namespace mithep
       mithep::VertexArr       *vertexes_;       //array of vertexes
       mithep::VertexMap       *vertexMap_;      //map wrt vertexes
       const mithep::TrackMap  *trackMap_; //map wrt tracker tracks
+      const mithep::CandidateMap *pfTrackMap_; //pat packed cand -> mithep::Track
   };
 }
 #endif

--- a/TreeFiller/python/MitTreeFiller_cfi.py
+++ b/TreeFiller/python/MitTreeFiller_cfi.py
@@ -160,21 +160,23 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
   ),
 
   PrimaryVertexes = cms.untracked.PSet(
-    active        = cms.untracked.bool(True),
-    mitName       = cms.untracked.string('PrimaryVertexes'),
-    edmName       = cms.untracked.string('offlinePrimaryVertices'),
-    vertexMapName = cms.untracked.string('PrimaryVertexMap'),
-    trackMapName  = cms.untracked.string('TracksMapName'),
-    fillerType    = cms.untracked.string('FillerVertexes')
+    active           = cms.untracked.bool(True),
+    mitName          = cms.untracked.string('PrimaryVertexes'),
+    edmName          = cms.untracked.string('offlinePrimaryVertices'),
+    vertexMapName    = cms.untracked.string('PrimaryVertexMap'),
+    trackMapName     = cms.untracked.string('TracksMapName'),
+    trkAssocByPacked = cms.untracked.bool(False),
+    fillerType       = cms.untracked.string('FillerVertexes')
   ),
 
   PrimaryVertexesBS = cms.untracked.PSet(
-    active        = cms.untracked.bool(True),
-    mitName       = cms.untracked.string('PrimaryVertexesBeamSpot'),
-    edmName       = cms.untracked.string('offlinePrimaryVerticesWithBS'),
-    vertexMapName = cms.untracked.string('PrimaryVertexBSMap'),
-    trackMapName  = cms.untracked.string('TracksMapName'),
-    fillerType    = cms.untracked.string('FillerVertexes')
+    active           = cms.untracked.bool(True),
+    mitName          = cms.untracked.string('PrimaryVertexesBeamSpot'),
+    edmName          = cms.untracked.string('offlinePrimaryVerticesWithBS'),
+    vertexMapName    = cms.untracked.string('PrimaryVertexBSMap'),
+    trackMapName     = cms.untracked.string('TracksMapName'),
+    trkAssocByPacked = cms.untracked.bool(False),
+    fillerType       = cms.untracked.string('FillerVertexes')
   ),
 
   InclusiveSecondaryVertexes = cms.untracked.PSet(
@@ -183,6 +185,7 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
     edmName       = cms.untracked.string('inclusiveSecondaryVertices'),
     vertexMapName = cms.untracked.string('InclusiveSecondaryVertexMap'),
     trackMapName  = cms.untracked.string('TracksMapName'),
+    trkAssocByPacked = cms.untracked.bool(False),
     fillerType    = cms.untracked.string('FillerVertexes')
   ),
 
@@ -664,6 +667,7 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
     bTaggingActive                           = cms.untracked.bool(True),
     jetToVertexActive                        = cms.untracked.bool(False),
     jetCorrectionsActive                     = cms.untracked.bool(True),
+    fillFromPAT                              = cms.untracked.bool(False),
     mitName                                  = cms.untracked.string('AKt4PFJets'),
     edmName                                  = cms.untracked.string('ak4PFJets'),
     rhoName                                  = cms.untracked.string('fixedGridRhoFastjetAll'),
@@ -686,7 +690,7 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
     TrackCountingHighPurBJetTagsName         = cms.untracked.string('trackCountingHighPurBJetTagsAKt4PF'),
     pfCandMapName                            = cms.untracked.string('PFCandMapName'),
     jetMapName                               = cms.untracked.string('AKt4PFJetMap'),
-    fillerType                               = cms.untracked.string('FillerPFJetsFromPFJets')
+    fillerType                               = cms.untracked.string('FillerPFJets')
   ),
 
   AKt4PFJetsCHS = cms.untracked.PSet(
@@ -695,6 +699,7 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
     bTaggingActive                           = cms.untracked.bool(True),
     jetToVertexActive                        = cms.untracked.bool(False),
     jetCorrectionsActive                     = cms.untracked.bool(True),
+    fillFromPAT                              = cms.untracked.bool(False),
     mitName                                  = cms.untracked.string('AKt4PFJetsCHS'),
     edmName                                  = cms.untracked.string('ak4PFJetsCHS'),
     rhoName                                  = cms.untracked.string('fixedGridRhoFastjetAll'),
@@ -717,7 +722,7 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
     TrackCountingHighPurBJetTagsName         = cms.untracked.string('trackCountingHighPurBJetTagsAKt4PFCHS'),
     pfCandMapName                            = cms.untracked.string('PFCandMapName'),
     jetMapName                               = cms.untracked.string('AKt4PFJetCHSMap'),
-    fillerType                               = cms.untracked.string('FillerPFJetsFromPFJets')
+    fillerType                               = cms.untracked.string('FillerPFJets')
   ),
 
   AKt8PFJets = cms.untracked.PSet(
@@ -726,6 +731,7 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
     bTaggingActive                           = cms.untracked.bool(False),
     jetToVertexActive                        = cms.untracked.bool(False),
     jetCorrectionsActive                     = cms.untracked.bool(False),
+    fillFromPAT                              = cms.untracked.bool(False),
     mitName                                  = cms.untracked.string('AKt8PFJets'),
     edmName                                  = cms.untracked.string('ak8PFJets'),
     rhoName                                  = cms.untracked.string(''),
@@ -737,7 +743,7 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
     flavorMatchingDefinition                 = cms.untracked.string('Algorithmic'),
     pfCandMapName                            = cms.untracked.string('PFCandMapName'),
     jetMapName                               = cms.untracked.string('AKT8PFJetMap'),
-    fillerType                               = cms.untracked.string('FillerPFJetsFromPFJets')
+    fillerType                               = cms.untracked.string('FillerPFJets')
   ),
 
   AKt8PFJetsCHS = cms.untracked.PSet(
@@ -746,6 +752,7 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
     bTaggingActive                           = cms.untracked.bool(False),
     jetToVertexActive                        = cms.untracked.bool(False),
     jetCorrectionsActive                     = cms.untracked.bool(False),
+    fillFromPAT                              = cms.untracked.bool(False),
     mitName                                  = cms.untracked.string('AKt8PFJetsCHS'),
     edmName                                  = cms.untracked.string('ak8PFJetsCHS'),
     rhoName                                  = cms.untracked.string(''),
@@ -757,7 +764,7 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
     flavorMatchingDefinition                 = cms.untracked.string('Algorithmic'),
     pfCandMapName                            = cms.untracked.string('PFCandMapName'), # ak8 CHS is not redone in BAMBU production
     jetMapName                               = cms.untracked.string('AKt8PFJetCHSMap'),
-    fillerType                               = cms.untracked.string('FillerPFJetsFromPFJets')
+    fillerType                               = cms.untracked.string('FillerPFJets')
   ),
 
   GenMet = cms.untracked.PSet(

--- a/TreeFiller/python/utils/configureForMiniAOD.py
+++ b/TreeFiller/python/utils/configureForMiniAOD.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.Types as Types
 
 def configureForMiniAOD(treeFiller):
     '''
@@ -43,173 +44,242 @@ def configureForMiniAOD(treeFiller):
         'AKT8GenJets',
         'GenMet'
     ]
-    treeFiller.Trigger.hltEvtEdmName = ''
-    treeFiller.Trigger.hltObjsEdmName = 'selectedPatTrigger'
 
-    treeFiller.MCParticles.genSource = 'PackedGenParticleCollection'
-    treeFiller.MCParticles.genEdmName = 'packedGenParticles'
+    psets = {
+        'Trigger': {
+            'hltEvtEdmName': '',
+            'hltObjsEdmName': 'selectedPatTrigger'
+        },
 
-    treeFiller.EvtSelData.patFilterResultsName = 'TriggerResults::PAT'
-    treeFiller.EvtSelData.HBHENoiseFilterName = 'Flag_HBHENoiseFilter'
-    treeFiller.EvtSelData.ECALDeadCellFilterName = 'Flag_EcalDeadCellTriggerPrimitiveFilter'  
-    treeFiller.EvtSelData.trackingFailureFilterName = 'Flag_trackingFailureFilter'  
-    treeFiller.EvtSelData.EEBadScFilterName = 'Flag_eeBadScFilter'  
-    treeFiller.EvtSelData.ECALaserCorrFilterName = 'Flag_ecalLaserCorrFilter'  
-    treeFiller.EvtSelData.tkManyStripClusName = 'Flag_trkPOG_manystripclus53X'  
-    treeFiller.EvtSelData.tkTooManyStripClusName = 'Flag_trkPOG_toomanystripclus53X'  
-    treeFiller.EvtSelData.tkLogErrorTooManyClustersName = 'Flag_trkPOG_logErrorTooManyClusters'  
-    treeFiller.EvtSelData.BeamHaloSummaryName = 'Flag_CSCTightHaloFilter'  
+        'MCParticles': {
+            'genSource': 'PackedGenParticleCollection',
+            'genEdmName': 'packedGenParticles'
+        },
 
-    treeFiller.SuperClusters.edmName = 'reducedEgamma:reducedSuperClusters'
-    treeFiller.SuperClusters.ebRecHitsName = ''
-    treeFiller.SuperClusters.eeRecHitsName = ''
-    treeFiller.SuperClusters.esRecHitsName = ''
-    treeFiller.SuperClusters.basicClusterMapName = ''
+        'EvtSelData': {
+            'patFilterResultsName': 'TriggerResults::PAT',
+            'HBHENoiseFilterName': 'Flag_HBHENoiseFilter',
+            'ECALDeadCellFilterName': 'Flag_EcalDeadCellTriggerPrimitiveFilter',
+            'trackingFailureFilterName': 'Flag_trackingFailureFilter',
+            'EEBadScFilterName': 'Flag_eeBadScFilter',
+            'ECALaserCorrFilterName': 'Flag_ecalLaserCorrFilter',
+            'tkManyStripClusName': 'Flag_trkPOG_manystripclus53X',
+            'tkTooManyStripClusName': 'Flag_trkPOG_toomanystripclus53X',
+            'tkLogErrorTooManyClustersName': 'Flag_trkPOG_logErrorTooManyClusters',
+            'BeamHaloSummaryName': 'Flag_CSCTightHaloFilter'
+        },
 
-    treeFiller.GeneralTracks.edmName = 'unpackedTracksAndVertices'
-    treeFiller.GeneralTracks.edmSimAssociationName = ''
+        'SuperClusters': {
+            'edmName': 'reducedEgamma:reducedSuperClusters',
+            'ebRecHitsName': '',
+            'eeRecHitsName': '',
+            'esRecHitsName': '',
+            'basicClusterMapName': ''
+        },
 
-    treeFiller.MuonTracks = cms.untracked.PSet(
-        active = cms.untracked.bool(True),
-        sourceType = cms.untracked.string('MuonInner'),
-        mitName = cms.untracked.string('MuonTracks'),
-        edmName = cms.untracked.string('slimmedMuons'),
-        trackMapName = cms.untracked.string('MuonTracksMapName'),
-        fillerType = cms.untracked.string('FillerTracks')
-    )
+        'GeneralTracks': {
+            'edmName': 'packedPFCandidates',
+            'edmSimAssociationName': '',
+            'trackingMapName': '',
+            'sourceType': 'PackedCandidates'
+        },
 
-    treeFiller.StandaloneMuonTracks.edmName = 'slimmedMuons'
-    treeFiller.StandaloneMuonTracks.sourceType = 'MuonStandalone'
+        'MuonTracks': cms.untracked.PSet(
+            active = cms.untracked.bool(True),
+            sourceType = cms.untracked.string('MuonInner'),
+            mitName = cms.untracked.string('MuonTracks'),
+            edmName = cms.untracked.string('slimmedMuons'),
+            trackMapName = cms.untracked.string('MuonTracksMapName'),
+            fillerType = cms.untracked.string('FillerTracks')
+        ),
 
-    treeFiller.GlobalMuonTracks.edmName = 'slimmedMuons'
-    treeFiller.GlobalMuonTracks.sourceType = 'MuonCombined'
+        'StandaloneMuonTracks': {
+            'edmName': 'slimmedMuons',
+            'sourceType': 'MuonStandalone'
+        },
+    
+        'GlobalMuonTracks': {
+            'edmName': 'slimmedMuons',
+            'sourceType': 'MuonCombined'
+        },
+    
+        'FirstHitMuonTracks': {
+            'edmName': 'slimmedMuons',
+            'sourceType': 'MuonTPFMS'
+        },
+    
+        'PickyMuonTracks': {
+            'edmName': 'slimmedMuons',
+            'sourceType': 'MuonPicky'
+        },
+    
+        'DYTMuonTracks': {
+            'edmName': 'slimmedMuons',
+            'sourceType': 'MuonDYT'
+        },
+    
+        'ElectronTracks': cms.untracked.PSet(
+            active = cms.untracked.bool(True),
+            sourceType = cms.untracked.string('ElectronCtf'),
+            mitName = cms.untracked.string('ElectronTracks'),
+            edmName = cms.untracked.string('slimmedElectrons'),
+            trackMapName = cms.untracked.string('ElectronTracksMapName'),
+            fillerType = cms.untracked.string('FillerTracks')
+        ),
+    
+        'GsfTracks': {
+            'edmName': 'slimmedElectrons',
+            'sourceType': 'ElectronGsf',
+            'trackingMapName': '',
+            'edmSimAssociationName': ''
+        },
+    
+        'PrimaryVertexes': {
+            'edmName': 'offlineSlimmedPrimaryVertices',
+            'trkAssocByPacked': True
+        },
 
-    treeFiller.FirstHitMuonTracks.edmName = 'slimmedMuons'
-    treeFiller.FirstHitMuonTracks.sourceType = 'MuonTPFMS'
+        'Muons': {
+            'edmName': 'slimmedMuons',
+            'pvEdmName': 'offlineSlimmedPrimaryVertices',
+            'pvBSEdmName': '',
+            'pvBeamSpotName': 'offlineBeamSpot',
+            'pvbsBeamSpotName': '',
+            'trackerTrackMapName': 'MuonTracksMapName',
+            'muonPFMapName': 'muonPFMap',
+            'fillFromPAT': True
+        },
+    
+        'Electrons': {
+            'edmName': 'slimmedElectrons',
+            'generalTracksName': '',
+            'gsfTracksName': '',
+            'conversionsName': '',
+            'pvbsBeamSpotName': '',
+            'footprintName': '',
+            'trackerTrackMapName': 'ElectronTracksMapName',
+            'pfEcalBarrelSuperClusterMapName': '',
+            'pfEcalEndcapSuperClusterMapName': '',
+            'electronPFMapName': 'electronPFMap',
+            'pvEdmName': 'offlineSlimmedPrimaryVertices',
+            'pvBSEdmName': '',
+            'fillFromPAT': True
+        },
 
-    treeFiller.PickyMuonTracks.edmName = 'slimmedMuons'
-    treeFiller.PickyMuonTracks.sourceType = 'MuonPicky'
+        'Conversions': {
+            'edmName': 'reducedEgamma:reducedConversions',
+            'stablePartMaps': []
+        },
+    
+        'PFCandidates': cms.untracked.PSet(
+            active = cms.untracked.bool(True),
+            mitName = cms.untracked.string('PFCandidates'),
+            edmName = cms.untracked.string('packedPFCandidates'),
+            pfCandMapName = cms.untracked.string('PFCandMapName'),
+            fillPfNoPileup = cms.untracked.bool(False),
+            electronMapName = cms.untracked.string('electronPFMap'),
+            muonMapName = cms.untracked.string('muonPFMap'),
+            photonMapName = cms.untracked.string('photonPFMap'),
+            trackMapName = cms.untracked.string('TracksMapName'),
+            fillerType = cms.untracked.string('FillerPackedPFCandidates')
+        ),
+    
+        'Photons': {
+            'edmName': 'slimmedPhotons',
+            'HBHERecHitsEdmName': '',
+            'phIDCutBasedTightName': 'PhotonCutBasedIDTight',
+            'phIDCutBasedLooseName': 'PhotonCutBasedIDLoose',
+            'footprintName': '',
+            'pfEcalBarrelSuperClusterMapName': '',
+            'pfEcalEndcapSuperClusterMapName': '',
+            'photonPFMapName': 'photonPFMap',
+            'fillFromPAT': True
+        },
+    
+        'AKt4PFJetsCHS': {
+            'edmName': 'slimmedJets',
+            'fillFromPAT': True,
+            'JetProbabilityBJetTagsName': 'pfJetProbabilityBJetTags',
+            'JetBProbabilityBJetTagsName': 'pfJetBProbabilityBJetTags',
+            'SimpleSecondaryVertexHighEffBJetTagsName': 'pfSimpleSecondaryVertexHighEffBJetTags',
+            'SimpleSecondaryVertexHighPurBJetTagsName': 'pfSimpleSecondaryVertexHighPurBJetTags',
+            'CombinedSecondaryVertexBJetTagsName': 'pfCombinedSecondaryVertexBJetTags',
+            'CombinedSecondaryVertexV2BJetTagsName': 'pfCombinedSecondaryVertexV2BJetTags',
+            'CombinedSecondaryVertexSoftLeptonBJetTagsName': 'pfCombinedSecondaryVertexSoftLeptonBJetTags',
+            'CombinedInclusiveSecondaryVertexV2BJetTagsName': 'pfCombinedInclusiveSecondaryVertexV2BJetTags',
+            'CombinedMVABJetTagsName': 'pfCombinedMVABJetTags',
+            'TrackCountingHighEffBJetTagsName': 'pfTrackCountingHighEffBJetTags',
+            'TrackCountingHighPurBJetTagsName': 'pfTrackCountingHighPurBJetTags',
+            'fillerType': 'FillerPFJets'
+        },
+    
+        'AKt8PFJetsCHS': {
+            'edmName': 'slimmedJetsAK8',
+            'fillFromPAT': True,
+            'fillerType': 'FillerPFJets'
+        },
+    
+        'PFMet': {
+            'edmName': 'slimmedMETs',
+            'fillerType': 'FillerPFMetFromPATMET'
+        },
+    
+        # HPS ID translation table -> http://cmslxr.fnal.gov/lxr/source/PhysicsTools/PatAlgos/python/tools/tauTools.py
+        # List of IDs included in pat::Tau -> vhttp://cmslxr.fnal.gov/lxr/source/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cfi.py
+        'HPSTaus': {
+            'edmName': 'slimmedTaus',
+            'DiscriminationByLooseElectronRejectionName': 'againstElectronLoose',
+            'DiscriminationByMediumElectronRejectionName': 'againstElectronMedium',
+            'DiscriminationByTightElectronRejectionName': 'againstElectronTight',
+            'DiscriminationByMVA5VLooseElectronRejectionName': 'againstElectronVLooseMVA5',
+            'DiscriminationByMVA5LooseElectronRejectionName': 'againstElectronLooseMVA5',
+            'DiscriminationByMVA5MediumElectronRejectionName': 'againstElectronMediumMVA5',
+            'DiscriminationByMVA5TightElectronRejectionName': 'againstElectronTightMVA5',
+            'DiscriminationByLooseMuonRejectionName': 'againstMuonLoose',
+            'DiscriminationByMediumMuonRejectionName': 'againstMuonMedium',
+            'DiscriminationByTightMuonRejectionName': 'againstMuonTight',
+            'DiscriminationByLooseMuonRejection2Name': 'againstMuonLoose2',
+            'DiscriminationByMediumMuonRejection2Name': 'againstMuonMedium2',
+            'DiscriminationByTightMuonRejection2Name': 'againstMuonTight2',
+            'DiscriminationByLooseMuonRejection3Name': 'againstMuonLoose3',
+            'DiscriminationByTightMuonRejection3Name': 'againstMuonTight3',
+            'DiscriminationByDecayModeFindingName': 'decayModeFinding',
+            'DiscriminationByDecayModeFindingNewDMsName': 'decayModeFindingNewDMs',
+            'DiscriminationByDecayModeFindingOldDMsName': '',
+            'DiscriminationByVLooseCombinedIsolationDBSumPtCorrName': '',
+            'DiscriminationByLooseCombinedIsolationDBSumPtCorrName': '',
+            'DiscriminationByMediumCombinedIsolationDBSumPtCorrName': '',
+            'DiscriminationByTightCombinedIsolationDBSumPtCorrName': '',
+            'DiscriminationByRawCombinedIsolationDBSumPtCorrName': '',
+            'DiscriminationByLooseCombinedIsolationDBSumPtCorr3HitsName': 'byLooseCombinedIsolationDeltaBetaCorr3Hits',
+            'DiscriminationByMediumCombinedIsolationDBSumPtCorr3HitsName': 'byMediumCombinedIsolationDeltaBetaCorr3Hits',
+            'DiscriminationByTightCombinedIsolationDBSumPtCorr3HitsName': 'byTightCombinedIsolationDeltaBetaCorr3Hits',
+            'DiscriminationByRawCombinedIsolationDBSumPtCorr3HitsName': 'byCombinedIsolationDeltaBetaCorrRaw3Hits',
+            'MVA3IsolationChargedIsoPtSumName': 'chargedIsoPtSum',
+            'MVA3IsolationNeutralIsoPtSumName': 'chargedIsoPtSum',
+            'MVA3IsolationPUcorrPtSumName': 'puCorrPtSum',
+            'fillerType': 'FillerPFTausFromPATTaus'
+        },
+    
+        'DCASig': {
+            'edmElectronName': 'slimmedElectrons',
+            'edmMuonName': 'slimmedMuons',
+            'edmTauName': 'slimmedTaus',
+            'edmTauType': 'PATTau'
+        },
+    
+        'GenMet': {
+            'edmName': 'slimmedMETs',
+            'fillFromPAT': True
+        }
+    }
 
-    treeFiller.DYTMuonTracks.edmName = 'slimmedMuons'
-    treeFiller.DYTMuonTracks.sourceType = 'MuonDYT'
+    # now configure the treeFiller
+    for fillerName, params in psets.items():
+        if type(params) == Types.PSet:
+            setattr(treeFiller, fillerName, params)
 
-    treeFiller.ElectronTracks = cms.untracked.PSet(
-        active = cms.untracked.bool(True),
-        sourceType = cms.untracked.string('ElectronCtf'),
-        mitName = cms.untracked.string('ElectronTracks'),
-        edmName = cms.untracked.string('slimmedElectrons'),
-        trackMapName = cms.untracked.string('ElectronTracksMapName'),
-        fillerType = cms.untracked.string('FillerTracks')
-    )
-
-    treeFiller.GsfTracks.edmName = 'slimmedElectrons'
-    treeFiller.GsfTracks.sourceType = 'ElectronGsf'
-    treeFiller.GsfTracks.trackingMapName = ''
-    treeFiller.GsfTracks.edmSimAssociationName = ''
-
-    treeFiller.PrimaryVertexes.edmName = 'offlineSlimmedPrimaryVertices'
-
-    treeFiller.Muons.edmName = 'slimmedMuons'
-    treeFiller.Muons.pvEdmName = 'offlineSlimmedPrimaryVertices'
-    treeFiller.Muons.pvBSEdmName = ''
-    treeFiller.Muons.pvBeamSpotName = 'offlineBeamSpot'
-    treeFiller.Muons.pvbsBeamSpotName = ''
-    treeFiller.Muons.trackerTrackMapName = 'MuonTracksMapName'
-    treeFiller.Muons.muonPFMapName = 'muonPFMap'
-    treeFiller.Muons.fillFromPAT = True
-
-    treeFiller.Electrons.edmName = 'slimmedElectrons'
-    treeFiller.Electrons.generalTracksName = ''
-    treeFiller.Electrons.gsfTracksName = ''
-    treeFiller.Electrons.conversionsName = ''
-    treeFiller.Electrons.pvbsBeamSpotName = ''
-    treeFiller.Electrons.footprintName = ''
-    treeFiller.Electrons.trackerTrackMapName = 'ElectronTracksMapName'
-    treeFiller.Electrons.pfEcalBarrelSuperClusterMapName = ''
-    treeFiller.Electrons.pfEcalEndcapSuperClusterMapName = ''
-    treeFiller.Electrons.electronPFMapName = 'electronPFMap'
-    treeFiller.Electrons.pvEdmName = 'offlineSlimmedPrimaryVertices'
-    treeFiller.Electrons.pvBSEdmName = ''
-    treeFiller.Electrons.fillFromPAT = True
-
-    treeFiller.Conversions.edmName = 'reducedEgamma:reducedConversions'
-    treeFiller.Conversions.stablePartMaps = []
-
-    treeFiller.PFCandidates.edmName = 'packedPFCandidates'
-    treeFiller.PFCandidates.electronMapName = 'electronPFMap'
-    treeFiller.PFCandidates.muonMapName = 'muonPFMap'
-    treeFiller.PFCandidates.photonMapName = 'photonPFMap'
-    treeFiller.PFCandidates.fillerType = 'FillerPackedPFCandidates'
-
-    treeFiller.Photons.edmName = 'slimmedPhotons'
-    treeFiller.Photons.HBHERecHitsEdmName = ''
-    treeFiller.Photons.phIDCutBasedTightName = 'PhotonCutBasedIDTight'
-    treeFiller.Photons.phIDCutBasedLooseName = 'PhotonCutBasedIDLoose'
-    treeFiller.Photons.footprintName = ''
-    treeFiller.Photons.pfEcalBarrelSuperClusterMapName = ''
-    treeFiller.Photons.pfEcalEndcapSuperClusterMapName = ''
-    treeFiller.Photons.photonPFMapName = 'photonPFMap'
-    treeFiller.Photons.fillFromPAT = True
-
-    treeFiller.AKt4PFJetsCHS.edmName = 'slimmedJets'
-    treeFiller.AKt4PFJetsCHS.JetProbabilityBJetTagsName = 'pfJetProbabilityBJetTags'
-    treeFiller.AKt4PFJetsCHS.JetBProbabilityBJetTagsName = 'pfJetBProbabilityBJetTags'
-    treeFiller.AKt4PFJetsCHS.SimpleSecondaryVertexHighEffBJetTagsName = 'pfSimpleSecondaryVertexHighEffBJetTags'
-    treeFiller.AKt4PFJetsCHS.SimpleSecondaryVertexHighPurBJetTagsName = 'pfSimpleSecondaryVertexHighPurBJetTags'
-    treeFiller.AKt4PFJetsCHS.CombinedSecondaryVertexBJetTagsName = 'pfCombinedSecondaryVertexBJetTags'
-    treeFiller.AKt4PFJetsCHS.CombinedSecondaryVertexV2BJetTagsName = 'pfCombinedSecondaryVertexV2BJetTags'
-    treeFiller.AKt4PFJetsCHS.CombinedSecondaryVertexSoftLeptonBJetTagsName = 'pfCombinedSecondaryVertexSoftLeptonBJetTags'
-    treeFiller.AKt4PFJetsCHS.CombinedInclusiveSecondaryVertexV2BJetTagsName = 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
-    treeFiller.AKt4PFJetsCHS.CombinedMVABJetTagsName = 'pfCombinedMVABJetTags'
-    treeFiller.AKt4PFJetsCHS.TrackCountingHighEffBJetTagsName = 'pfTrackCountingHighEffBJetTags'
-    treeFiller.AKt4PFJetsCHS.TrackCountingHighPurBJetTagsName = 'pfTrackCountingHighPurBJetTags'
-    treeFiller.AKt4PFJetsCHS.fillerType = 'FillerPFJetsFromPATJets'
-
-    treeFiller.AKt8PFJetsCHS.edmName = 'slimmedJetsAK8'
-    treeFiller.AKt8PFJetsCHS.fillerType = 'FillerPFJetsFromPATJets'
-
-    treeFiller.PFMet.edmName = 'slimmedMETs'
-    treeFiller.PFMet.fillerType = 'FillerPFMetFromPATMET'
-
-    # HPS ID translation table -> http://cmslxr.fnal.gov/lxr/source/PhysicsTools/PatAlgos/python/tools/tauTools.py
-    # List of IDs included in pat::Tau -> vhttp://cmslxr.fnal.gov/lxr/source/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cfi.py
-    treeFiller.HPSTaus.edmName = 'slimmedTaus'
-    treeFiller.HPSTaus.DiscriminationByLooseElectronRejectionName = 'againstElectronLoose'
-    treeFiller.HPSTaus.DiscriminationByMediumElectronRejectionName = 'againstElectronMedium'
-    treeFiller.HPSTaus.DiscriminationByTightElectronRejectionName = 'againstElectronTight'
-    treeFiller.HPSTaus.DiscriminationByMVA5VLooseElectronRejectionName = 'againstElectronVLooseMVA5'
-    treeFiller.HPSTaus.DiscriminationByMVA5LooseElectronRejectionName = 'againstElectronLooseMVA5'
-    treeFiller.HPSTaus.DiscriminationByMVA5MediumElectronRejectionName = 'againstElectronMediumMVA5'
-    treeFiller.HPSTaus.DiscriminationByMVA5TightElectronRejectionName = 'againstElectronTightMVA5'
-    treeFiller.HPSTaus.DiscriminationByLooseMuonRejectionName = 'againstMuonLoose'
-    treeFiller.HPSTaus.DiscriminationByMediumMuonRejectionName = 'againstMuonMedium'
-    treeFiller.HPSTaus.DiscriminationByTightMuonRejectionName = 'againstMuonTight'
-    treeFiller.HPSTaus.DiscriminationByLooseMuonRejection2Name = 'againstMuonLoose2'
-    treeFiller.HPSTaus.DiscriminationByMediumMuonRejection2Name = 'againstMuonMedium2'
-    treeFiller.HPSTaus.DiscriminationByTightMuonRejection2Name = 'againstMuonTight2'
-    treeFiller.HPSTaus.DiscriminationByLooseMuonRejection3Name = 'againstMuonLoose3'
-    treeFiller.HPSTaus.DiscriminationByTightMuonRejection3Name = 'againstMuonTight3'
-    treeFiller.HPSTaus.DiscriminationByDecayModeFindingName = 'decayModeFinding'
-    treeFiller.HPSTaus.DiscriminationByDecayModeFindingNewDMsName = 'decayModeFindingNewDMs'
-    treeFiller.HPSTaus.DiscriminationByDecayModeFindingOldDMsName = ''
-    treeFiller.HPSTaus.DiscriminationByVLooseCombinedIsolationDBSumPtCorrName = ''
-    treeFiller.HPSTaus.DiscriminationByLooseCombinedIsolationDBSumPtCorrName = ''
-    treeFiller.HPSTaus.DiscriminationByMediumCombinedIsolationDBSumPtCorrName = ''
-    treeFiller.HPSTaus.DiscriminationByTightCombinedIsolationDBSumPtCorrName = ''
-    treeFiller.HPSTaus.DiscriminationByRawCombinedIsolationDBSumPtCorrName = ''
-    treeFiller.HPSTaus.DiscriminationByLooseCombinedIsolationDBSumPtCorr3HitsName = 'byLooseCombinedIsolationDeltaBetaCorr3Hits'
-    treeFiller.HPSTaus.DiscriminationByMediumCombinedIsolationDBSumPtCorr3HitsName = 'byMediumCombinedIsolationDeltaBetaCorr3Hits'
-    treeFiller.HPSTaus.DiscriminationByTightCombinedIsolationDBSumPtCorr3HitsName = 'byTightCombinedIsolationDeltaBetaCorr3Hits'
-    treeFiller.HPSTaus.DiscriminationByRawCombinedIsolationDBSumPtCorr3HitsName = 'byCombinedIsolationDeltaBetaCorrRaw3Hits'
-    treeFiller.HPSTaus.MVA3IsolationChargedIsoPtSumName = 'chargedIsoPtSum'
-    treeFiller.HPSTaus.MVA3IsolationNeutralIsoPtSumName = 'chargedIsoPtSum'
-    treeFiller.HPSTaus.MVA3IsolationPUcorrPtSumName = 'puCorrPtSum'
-    treeFiller.HPSTaus.fillerType = 'FillerPFTausFromPATTaus'
-
-    treeFiller.DCASig.edmElectronName = 'slimmedElectrons'
-    treeFiller.DCASig.edmMuonName = 'slimmedMuons'
-    treeFiller.DCASig.edmTauName = 'slimmedTaus'
-    treeFiller.DCASig.edmTauType = 'PATTau'
-
-    treeFiller.GenMet.edmName = 'slimmedMETs'
-    treeFiller.GenMet.fillFromPAT = True
+        else:
+            filler = getattr(treeFiller, fillerName)
+            for paramName, value in params.items():
+                setattr(filler, paramName, value)

--- a/TreeFiller/src/FillerJets.cc
+++ b/TreeFiller/src/FillerJets.cc
@@ -1,0 +1,225 @@
+#include "MitProd/TreeFiller/interface/FillerJets.h"
+
+#include "SimDataFormats/JetMatching/interface/MatchedPartons.h"
+
+mithep::FillerJets::FillerJets(edm::ParameterSet const& cfg, edm::ConsumesCollector& collector, ObjectService* os, char const* name, bool active/* = true*/) :
+  BaseFiller(cfg, os, name, active),
+  flavorMatchingActive_(cfg.getUntrackedParameter<bool>("flavorMatchingActive", true)),
+  bTaggingActive_(cfg.getUntrackedParameter<bool>("bTaggingActive", true)),
+  jetToVertexActive_(cfg.getUntrackedParameter<bool>("jetToVertexActive", true)),
+  jetCorrectionsActive_(cfg.getUntrackedParameter<bool>("jetCorrectionsActive", true)),
+  edmToken_(GetToken<reco::JetView>(collector, cfg, "edmName")),
+  jetToVertexAlphaToken_(GetToken<std::vector<double> >(collector, cfg, "jetToVertexAlphaName", jetToVertexActive_)), //jetToVertexAlpha
+  jetToVertexBetaToken_(GetToken<std::vector<double> >(collector, cfg, "jetToVertexBetaName", jetToVertexActive_)), //jetToVertexBetaName
+  flavorMatchingByReferenceToken_(GetToken<reco::JetMatchedPartonsCollection>(collector, cfg, "flavorMatchingByReferenceName", flavorMatchingActive_)), //srcByReference
+  bJetTagsToken_{},
+  rhoToken_(GetToken<double>(collector, cfg, "rhoName", jetCorrectionsActive_)),
+  mitName_(cfg.getUntrackedParameter<string>("mitName")),
+  L2JetCorrectorName_(cfg.getUntrackedParameter<std::string>("L2JetCorrectorName", "L2JetCorrectorName")),
+  L3JetCorrectorName_(cfg.getUntrackedParameter<std::string>("L3JetCorrectorName", "L3JetCorrectorName")),
+  jetMapName_(cfg.getUntrackedParameter<string>("jetMapName")),
+  flavorMatchingDefinition_{},
+  rho_(0.),
+  L2Corrector_(0),
+  L3Corrector_(0),
+  jetMap_(new JetMap),
+  jets_(0)
+{
+  for (unsigned iA = 0; iA != mithep::Jet::nBTagAlgos; ++iA) {
+    std::string paramName(mithep::Jet::BTagAlgoName(iA) + std::string("BJetTagsName"));
+    bJetTagsToken_[iA] = GetToken<reco::JetTagCollection>(collector, cfg, paramName, false);
+  }
+
+  std::string defName(cfg.getUntrackedParameter<std::string>("flavorMatchingDefinition", "Algorithmic"));
+  if (defName == "Algorithmic")
+    flavorMatchingDefinition_ = kAlgorithmic;
+  else if (defName == "Physics")
+    flavorMatchingDefinition_ = kPhysics;
+  else
+    throw edm::Exception(edm::errors::Configuration, "FillerJets::Ctor")
+      << "Invalid flavor matching definition";
+}
+
+mithep::FillerJets::~FillerJets()
+{
+  delete jetMap_;
+  delete jets_;
+}
+
+void
+mithep::FillerJets::BookDataBlock(TreeWriter& tws)
+{
+  tws.AddBranch(mitName_, &jets_);
+  OS()->add(jets_, mitName_);
+
+  if (!jetMapName_.empty()) {
+    jetMap_->SetBrName(mitName_);
+    OS()->add(jetMap_, jetMapName_);
+  }
+
+  BookAdditional(tws);
+
+  // Set "MustDelete" bit of Array so that Reset() in the FillDataBlock will flush the content
+  jets_->SetBit(15);
+}
+
+void
+mithep::FillerJets::FillDataBlock(edm::Event const& event, edm::EventSetup const& setup)
+{
+  // with MustDelete bit set, Reset() is equivalent to Delete()
+  jets_->Reset();
+  jetMap_->Reset();
+  
+  edm::Handle<reco::JetView> hJetsH;
+  GetProduct(edmToken_, hJetsH, event);
+  auto& inJets = *hJetsH;
+  
+  // handles for jet flavour matching 
+  reco::JetMatchedPartonsCollection const* matchedPartons = 0;
+  if (flavorMatchingActive_) {
+    edm::Handle<reco::JetMatchedPartonsCollection> hMatchH;
+    GetProduct(flavorMatchingByReferenceToken_, hMatchH, event);
+    matchedPartons = hMatchH.product();
+  }
+
+  reco::JetTagCollection const* bJetTags[mithep::Jet::nBTagAlgos] = {};
+
+  if (bTaggingActive_)
+    initBJetTags(event, bJetTags);
+
+  if (jetCorrectionsActive_)
+    initCorrections(event, setup);
+  
+  std::vector<double> const* jvAlpha = 0; 
+  std::vector<double> const* jvBeta = 0;
+  if (jetToVertexActive_) {
+    edm::Handle<std::vector<double>> jvAlphaH;
+    edm::Handle<std::vector<double>> jvBetaH;
+    GetProduct(jetToVertexAlphaToken_, jvAlphaH, event); 
+    GetProduct(jetToVertexBetaToken_, jvBetaH, event);  
+    jvAlpha = jvAlphaH.product();
+    jvBeta = jvBetaH.product();
+  }
+
+  PrepareSpecific(event, setup);
+
+  // loop through all jets
+  for (unsigned iJ = 0; iJ != inJets.size(); ++iJ) {
+    auto& inJet = inJets.at(iJ);
+    auto&& baseRef = inJets.refAt(iJ);
+    
+    mithep::Jet* outJet = AddNew();
+
+    jetMap_->Add(inJets.ptrAt(iJ), outJet);
+
+    // for pat::Jets, p4() is already corrected - fixed in FillSpecific
+    outJet->SetRawPtEtaPhiM(inJet.p4().pt(), inJet.p4().eta(), inJet.p4().phi(), inJet.p4().mass());
+
+    //fill jet moments
+    outJet->SetSigmaEta(TMath::Sqrt(inJet.etaetaMoment()));
+    outJet->SetSigmaPhi(TMath::Sqrt(inJet.phiphiMoment()));
+
+    //fill jet area
+    outJet->SetJetArea(inJet.jetArea());
+
+    FillSpecific(*outJet, baseRef);
+
+    if (jetToVertexActive_) {
+      //compute alpha and beta parameter for jets
+      outJet->SetAlpha(jvAlpha->at(iJ));
+      outJet->SetBeta(jvBeta->at(iJ));      
+    }
+
+    if (bTaggingActive_)
+      setBJetTags(*outJet, baseRef, bJetTags);
+
+    if (jetCorrectionsActive_)
+      setCorrections(*outJet, inJet);
+
+    // get the Monte Carlo flavour matching information
+    if (flavorMatchingActive_) {
+      auto&& matchedParton = (*matchedPartons)[matchedPartons->key(iJ)];
+
+      outJet->SetMatchedMCFlavor(0);      
+      switch (flavorMatchingDefinition_) {
+      case kAlgorithmic:
+        if (matchedParton.algoDefinitionParton().isNonnull())
+          outJet->SetMatchedMCFlavor(matchedParton.algoDefinitionParton()->pdgId());
+        break;
+
+      case kPhysics:
+        if (matchedParton.physicsDefinitionParton().isNonnull())
+          outJet->SetMatchedMCFlavor(matchedParton.physicsDefinitionParton()->pdgId());
+        break;
+
+      default:
+        break;
+      }
+    }
+  }
+
+  jets_->Trim();
+}
+
+void
+mithep::FillerJets::FillPostRunBlock(edm::Run const&, edm::EventSetup const&)
+{
+  // Unset the "MustDelete" bit before writing the branch to the tree
+  jets_->ResetBit(15);
+}
+
+void
+mithep::FillerJets::initBJetTags(edm::Event const& event,
+                                         reco::JetTagCollection const* bJetTags[mithep::Jet::nBTagAlgos])
+{
+  for (unsigned iT = 0; iT != mithep::Jet::nBTagAlgos; ++iT) {
+    edm::Handle<reco::JetTagCollection> hBJetTags;
+    if (GetProductSafe(bJetTagsToken_[iT], hBJetTags, event))
+      bJetTags[iT] = hBJetTags.product();
+  }
+}
+
+void
+mithep::FillerJets::setBJetTags(mithep::Jet& outJet, reco::JetBaseRef const& baseRef,
+                                        reco::JetTagCollection const* bJetTags[mithep::Jet::nBTagAlgos]) const
+{
+  for (unsigned iT = 0; iT != mithep::Jet::nBTagAlgos; ++iT) {
+    if (bJetTags[iT])
+      outJet.SetBJetTagsDisc((*bJetTags[iT])[baseRef], iT);
+  }
+}
+
+void
+mithep::FillerJets::initCorrections(edm::Event const& event, edm::EventSetup const& setup)
+{
+  edm::Handle<double> hRho;
+  GetProduct(rhoToken_, hRho, event);
+  rho_ = *hRho;
+
+  L2Corrector_ = JetCorrector::getJetCorrector(L2JetCorrectorName_, setup);
+  L3Corrector_ = JetCorrector::getJetCorrector(L3JetCorrectorName_, setup);
+}
+
+void
+mithep::FillerJets::setCorrections(mithep::Jet& outJet, reco::Jet const&)
+{
+  // jet corrections
+
+  double L1Scale = std::max((outJet.RawMom().pt() - rho_ * outJet.JetArea()) / outJet.RawMom().pt(), 0.);
+  outJet.SetL1OffsetCorrectionScale(L1Scale);
+  outJet.EnableCorrection(mithep::Jet::L1);
+
+  FourVector p4(outJet.RawMom().Px(), outJet.RawMom().Py(), outJet.RawMom().Pz(), outJet.RawMom().E());
+
+  p4 *= L1Scale;
+
+  double L2Scale = L2Corrector_->correction(p4);
+  outJet.SetL2RelativeCorrectionScale(L2Scale);
+  outJet.EnableCorrection(mithep::Jet::L2);
+
+  p4 *= L2Scale;
+
+  double L3Scale = L3Corrector_->correction(p4);
+  outJet.SetL3AbsoluteCorrectionScale(L3Scale);
+  outJet.EnableCorrection(mithep::Jet::L3);
+}

--- a/TreeFiller/src/FillerTrackJets.cc
+++ b/TreeFiller/src/FillerTrackJets.cc
@@ -1,5 +1,3 @@
-#define FILLERJETS_INSTANCE
-
 #include "MitProd/TreeFiller/interface/FillerTrackJets.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -8,12 +6,13 @@
 #include "DataFormats/Common/interface/RefToPtr.h"
 
 mithep::FillerTrackJets::FillerTrackJets(edm::ParameterSet const& cfg, edm::ConsumesCollector& collector, mithep::ObjectService* os, char const* name, bool active/* = true*/) : 
-  FillerJets<mithep::TrackJet>(cfg, collector, os, name, active),
+  FillerJets(cfg, collector, os, name, active),
   trackMapName_(cfg.getUntrackedParameter<string>("trackMapName","trackMapName")),
   vertexMapName_(cfg.getUntrackedParameter<string>("vertexMapName","")),
   trackMap_(0),
   vertexMap_(0)
 {
+  jets_ = new mithep::TrackJetArr(32);
 }
 
 mithep::FillerTrackJets::~FillerTrackJets()
@@ -44,7 +43,7 @@ mithep::FillerTrackJets::ResolveLinks(edm::Event const& event, edm::EventSetup c
   for (auto& mapElem : jetMap_->FwdMap()) {
     auto&& jPtr = mapElem.first;
     auto& inJet = static_cast<reco::TrackJet const&>(*jPtr);
-    auto& outJet = *mapElem.second;
+    auto& outJet = static_cast<mithep::TrackJet&>(*mapElem.second);
 
     //fill primary vertex reference
     if (vertexMap_ && inJet.primaryVertex().isNonnull())

--- a/TreeFiller/src/FillerTracks.cc
+++ b/TreeFiller/src/FillerTracks.cc
@@ -33,7 +33,8 @@ mithep::FillerTracks::FillerTracks(edm::ParameterSet const& cfg, edm::ConsumesCo
   assocParams_(0),
   trackMap_(0),
   eleTrackMap_(0),
-  muTrackMap_(0)
+  muTrackMap_(0),
+  pfTrackMap_(0)
 {
   std::string sourceType(cfg.getUntrackedParameter<std::string>("sourceType", "Tracks"));
   if (sourceType == "Tracks")
@@ -54,6 +55,8 @@ mithep::FillerTracks::FillerTracks(edm::ParameterSet const& cfg, edm::ConsumesCo
     sourceType_ = kMuonPicky;
   else if (sourceType == "MuonDYT")
     sourceType_ = kMuonDYT;
+  else if (sourceType == "PackedCandidates")
+    sourceType_ = kPackedCandidates;
   else
     throw edm::Exception(edm::errors::Configuration, "FillerTracks::Ctor")
       << "Invalid source type " << sourceType;
@@ -84,6 +87,9 @@ mithep::FillerTracks::FillerTracks(edm::ParameterSet const& cfg, edm::ConsumesCo
   case kMuonDYT:
     edmMuonToken_ = GetToken<MuonView>(collector, cfg, "edmName"); //slimmedMuons
     break;
+  case kPackedCandidates:
+    edmPackedCandToken_ = GetToken<PackedCandView>(collector, cfg, "edmName"); //packedCandidates
+    break;
   default:
     break;
   }
@@ -103,6 +109,7 @@ mithep::FillerTracks::~FillerTracks()
   delete trackMap_;
   delete eleTrackMap_;
   delete muTrackMap_;
+  delete pfTrackMap_;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -135,6 +142,11 @@ mithep::FillerTracks::BookDataBlock(TreeWriter& tws)
     muTrackMap_ = new mithep::MuonTrackMap;
     muTrackMap_->SetBrName(mitName_);
     OS()->add(muTrackMap_, trackMapName_);
+    break;
+  case kPackedCandidates:
+    pfTrackMap_ = new mithep::CandidateMap;
+    pfTrackMap_->SetBrName(mitName_);
+    OS()->add(pfTrackMap_, trackMapName_);
     break;
   default:
     break;
@@ -173,10 +185,13 @@ mithep::FillerTracks::FillDataBlock(edm::Event const& event, edm::EventSetup con
     eleTrackMap_->Reset();
   if (muTrackMap_)
     muTrackMap_->Reset();
+  if (pfTrackMap_)
+    pfTrackMap_->Reset();
 
   TrackView const* tracksView = 0;
   ElectronView const* electronsView = 0;
   MuonView const* muonsView = 0;
+  PackedCandView const* packedCandView = 0;
 
   switch (sourceType_) {
   case kTracks:
@@ -205,6 +220,13 @@ mithep::FillerTracks::FillDataBlock(edm::Event const& event, edm::EventSetup con
       edm::Handle<MuonView> hMuons;
       GetProduct(edmMuonToken_, hMuons, event);
       muonsView = hMuons.product();
+    }
+    break;
+  case kPackedCandidates:
+    {
+      edm::Handle<PackedCandView> hCands;
+      GetProduct(edmPackedCandToken_, hCands, event);
+      packedCandView = hCands.product();
     }
     break;
   default:
@@ -298,6 +320,18 @@ mithep::FillerTracks::FillDataBlock(edm::Event const& event, edm::EventSetup con
 
   case kMuonDYT:
     fillMuonMap(reco::Muon::DYT);
+    break;
+
+  case kPackedCandidates:
+    for (auto&& cPtr : packedCandView->ptrs()) {
+      auto& cand(*cPtr);
+      if (cand.charge() == 0 || cand.numberOfHits() <= 0)
+        continue;
+
+      auto* outTrack = ProduceTrack(cand.pseudoTrack());
+      pfTrackMap_->Add(cPtr, outTrack);
+      inOutPairs.push_back(InOutPair(&cand.pseudoTrack(), outTrack));
+    }
     break;
 
   default:

--- a/TreeFiller/src/FillerTracks.cc
+++ b/TreeFiller/src/FillerTracks.cc
@@ -325,7 +325,7 @@ mithep::FillerTracks::FillDataBlock(edm::Event const& event, edm::EventSetup con
   case kPackedCandidates:
     for (auto&& cPtr : packedCandView->ptrs()) {
       auto& cand(*cPtr);
-      if (cand.charge() == 0 || cand.numberOfHits() <= 0)
+      if (cand.charge() == 0 || cand.numberOfHits() == 0)
         continue;
 
       auto* outTrack = ProduceTrack(cand.pseudoTrack());

--- a/TreeFiller/src/FillerVertexes.cc
+++ b/TreeFiller/src/FillerVertexes.cc
@@ -114,8 +114,24 @@ void FillerVertexes::ResolveLinks(const edm::Event& event, const edm::EventSetup
         if (vtxRef.isNull() || vtxRef.get() != &inVertex)
           continue;
 
+        double weight = -1.;
+        switch (cand.pvAssociationQuality()) {
+        case pat::PackedCandidate::CompatibilityBTag:
+        case pat::PackedCandidate::CompatibilityDz:
+          weight = 0.;
+          break;
+        case pat::PackedCandidate::UsedInFitLoose:
+          weight = 0.5;
+          break;
+        case pat::PackedCandidate::UsedInFitTight:
+          weight = 1.;
+          break;
+        default:
+          break;
+        }
+
         mithep::Track const* track = static_cast<mithep::Track const*>(pfTrackElem.second);
-        outVertex->AddTrack(track);
+        outVertex->AddTrack(track, weight);
       }
     }
   }

--- a/TreeFiller/src/FillerVertexes.cc
+++ b/TreeFiller/src/FillerVertexes.cc
@@ -12,22 +12,21 @@ using namespace mithep;
 //--------------------------------------------------------------------------------------------------
 FillerVertexes::FillerVertexes(const ParameterSet &cfg, edm::ConsumesCollector& collector, ObjectService* os, const char *name, bool active) : 
   BaseFiller(cfg,os,name,active),
+  trkAssocByPacked_(cfg.getUntrackedParameter<bool>("trkAssocByPacked", false)),
   edmToken_(GetToken<reco::VertexCollection>(collector, cfg, "edmName")), //offlinePrimaryVertices
   mitName_(cfg.getUntrackedParameter<string>("mitName","PrimaryVertexes")),
   trackMapName_(cfg.getUntrackedParameter<string>("trackMapName","")),
   vertexMapName_(cfg.getUntrackedParameter<string>("vertexMapName","VertexMap")),
   vertexes_(new mithep::VertexArr(100)),
   vertexMap_(new mithep::VertexMap),
-  trackMap_(0)
+  trackMap_(0),
+  pfTrackMap_(0)
 {
-  // Constructor.
 }
 
 //--------------------------------------------------------------------------------------------------
 FillerVertexes::~FillerVertexes()
 {
-  // Destructor.
-
   delete vertexes_;
   delete vertexMap_;
 }
@@ -44,10 +43,21 @@ void FillerVertexes::BookDataBlock(TreeWriter &tws)
     vertexMap_->SetBrName(mitName_);
     OS()->add<VertexMap>(vertexMap_,vertexMapName_);
   }
+}
+
+void FillerVertexes::PrepareLinks()
+{
   if (!trackMapName_.empty()) {
-    trackMap_ = OS()->get<TrackMap>(trackMapName_);
-    if (trackMap_)
-      AddBranchDep(mitName_,trackMap_->GetBrName());
+    if (trkAssocByPacked_) {
+      pfTrackMap_ = OS()->get<CandidateMap>(trackMapName_);
+      if (pfTrackMap_)
+        AddBranchDep(mitName_, pfTrackMap_->GetBrName());
+    }
+    else {
+      trackMap_ = OS()->get<TrackMap>(trackMapName_);
+      if (trackMap_)
+        AddBranchDep(mitName_,trackMap_->GetBrName());
+    }
   }
 }
 
@@ -77,19 +87,39 @@ void FillerVertexes::FillDataBlock(const edm::Event      &event,
     outVertex->SetNdof(inV->ndof());
     outVertex->SetNTracksFit(inV->tracksSize());
 
-    //fill tracks associated to the vertex
-    if (trackMap_) {
-      for (reco::Vertex::trackRef_iterator iTrack = inV->tracks_begin(); iTrack!=inV->tracks_end(); ++iTrack) {
-        outVertex->AddTrack(trackMap_->GetMit(mitedm::refToBaseToPtr(*iTrack)), inV->trackWeight(*iTrack));
-      }
-    }
-
     //add vertex to the map
     mitedm::VertexPtr thePtr(hVertexProduct, inV-inVertexes.begin());
     vertexMap_->Add(thePtr, outVertex);
-         
   }
   vertexes_->Trim();
 }
+
+void FillerVertexes::ResolveLinks(const edm::Event& event, const edm::EventSetup&)
+{
+  for (auto&& mapElem : vertexMap_->FwdMap()) {
+    auto& inVertex = *mapElem.first;
+    auto* outVertex = mapElem.second;
+
+    //fill tracks associated to the vertex
+    if (trackMap_) {
+      for (auto&& iTrack = inVertex.tracks_begin(); iTrack != inVertex.tracks_end(); ++iTrack)
+        outVertex->AddTrack(trackMap_->GetMit(mitedm::refToBaseToPtr(*iTrack)), inVertex.trackWeight(*iTrack));
+    }
+    else if (pfTrackMap_) {
+      for (auto&& pfTrackElem : pfTrackMap_->FwdMap()) {
+        pat::PackedCandidate const& cand = static_cast<pat::PackedCandidate const&>(*pfTrackElem.first);
+
+        auto&& vtxRef = cand.vertexRef();
+        // should always be non-null, but just in case
+        if (vtxRef.isNull() || vtxRef.get() != &inVertex)
+          continue;
+
+        mithep::Track const* track = static_cast<mithep::Track const*>(pfTrackElem.second);
+        outVertex->AddTrack(track);
+      }
+    }
+  }
+}
+
 
 DEFINE_MITHEP_TREEFILLER(FillerVertexes);


### PR DESCRIPTION
I wasn't paying attention to the fact that the track collection unpacked from MiniAOD packedPFCandidates using the CMSSW tool for it will inevitably not have links to vertices. Since the implementation of the unpacker is very straightforward, in this version we do the unpacking and vertex-track linking within Bambu (i.e. FillerTracks and FillerVertices communicates through packedPFCandidates themselves, instead of unpacked reco::Tracks).
