### PR TITLE
setting default HBHENoisefilter to 25ns + new 50ns configurations

### DIFF
--- a/Processing/filefi/042/data-50ns.py
+++ b/Processing/filefi/042/data-50ns.py
@@ -15,7 +15,7 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source(
   "PoolSource",
-  fileNames = cms.untracked.vstring('root://xrootd.unl.edu//store/data/Run2015C/DoubleMuon/AOD/PromptReco-v1/000/254/227/00000/A0F6935F-2A46-E511-9482-02163E014568.root')
+  fileNames = cms.untracked.vstring('root://xrootd.unl.edu//store/data/Run2015B/SingleMu/AOD/PromptReco-v1/000/251/028/00000/924F6240-3C26-E511-B55B-02163E0144CC.root')
 )
 process.source.inputCommands = cms.untracked.vstring(
   "keep *",
@@ -178,6 +178,8 @@ MitTreeFiller.MCVertexes.active = False
 MitTreeFiller.PileupInfo.active = False
 MitTreeFiller.AKT4GenJets.active = False
 MitTreeFiller.AKT8GenJets.active = False
+# MET filter configuration
+MitTreeFiller.EvtSelData.HBHENoiseFilterName = 'HBHENoiseFilterResultProducer:HBHENoiseFilterResult'
 
 # define fill bambu filler sequence
 

--- a/Processing/filefi/042/mc.py
+++ b/Processing/filefi/042/mc.py
@@ -18,7 +18,6 @@ process.source = cms.Source(
   "PoolSource",
   # make sure this is for the right version
   fileNames = cms.untracked.vstring('root://xrootd.unl.edu//store/mc/RunIISpring15DR74/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/AODSIM/Asympt25ns_MCRUN2_74_V9-v1/60000/000A6F75-5601-E511-BF58-00259074AE32.root')
-#  fileNames = cms.untracked.vstring('root://xrootd.unl.edu//store/mc/RunIISpring15DR74/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/AODSIM/Asympt25ns_MCRUN2_74_V9-v1/00000/DA235DE2-9801-E511-8E49-00259073E356.root')
 )
 process.source.inputCommands = cms.untracked.vstring(
   "keep *",

--- a/TreeFiller/python/MitTreeFiller_cfi.py
+++ b/TreeFiller/python/MitTreeFiller_cfi.py
@@ -138,7 +138,7 @@ MitTreeFiller = cms.EDAnalyzer("FillMitTree",
     active                        = cms.untracked.bool(True),
     mitName                       = cms.untracked.string('EvtSelData'),
     HBHENoiseFilterName           = cms.untracked.string('HBHENoiseFilterResultProducer:'+
-                                                         'HBHENoiseFilterResult'),
+                                                         'HBHENoiseFilterResultRun2Loose'),
     ECALDeadCellFilterName        = cms.untracked.string('EcalDeadCellTriggerPrimitiveFilter'),
     trackingFailureFilterName     = cms.untracked.string('trackingFailureFilter'),
     EEBadScFilterName             = cms.untracked.string('eeBadScFilter'),


### PR DESCRIPTION
HBHENoiseFilter setup in MitTreeFiller_cfi.py is now for 25 ns.
data-50ns.py and mc-50ns.py in the Processing/filefi/042 directory are added with 50 ns HBHE filter setup + proper global tag. data.py and mc.py are basically unchanged.
