### PR TITLE
Fatjet fixes

### DIFF
--- a/Configuration/python/BambuProdAodsim.py
+++ b/Configuration/python/BambuProdAodsim.py
@@ -8,15 +8,14 @@ process = cms.Process('FILEFI')
 
 # say how many events to process (-1 means no limit)
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(20)
+  input = cms.untracked.int32(100)
 )
 
 #>> input source
 
 process.source = cms.Source(
   "PoolSource",
-#  fileNames = cms.untracked.vstring('root://xrootd.unl.edu//store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-amcatnlo-pythia8/AODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/30000/029641E2-37A2-E511-9AB4-A0369F7F8E80.root')
-  fileNames = cms.untracked.vstring('file:/local/snarayan/aodsim_test.root')
+  fileNames = cms.untracked.vstring('root://xrootd.unl.edu//store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-amcatnlo-pythia8/AODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/30000/029641E2-37A2-E511-9AB4-A0369F7F8E80.root')
 )
 process.source.inputCommands = cms.untracked.vstring(
   "keep *",

--- a/Configuration/python/BambuProdAodsim.py
+++ b/Configuration/python/BambuProdAodsim.py
@@ -8,14 +8,15 @@ process = cms.Process('FILEFI')
 
 # say how many events to process (-1 means no limit)
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(100)
+  input = cms.untracked.int32(20)
 )
 
 #>> input source
 
 process.source = cms.Source(
   "PoolSource",
-  fileNames = cms.untracked.vstring('root://xrootd.unl.edu//store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-amcatnlo-pythia8/AODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/30000/029641E2-37A2-E511-9AB4-A0369F7F8E80.root')
+#  fileNames = cms.untracked.vstring('root://xrootd.unl.edu//store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-amcatnlo-pythia8/AODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/30000/029641E2-37A2-E511-9AB4-A0369F7F8E80.root')
+  fileNames = cms.untracked.vstring('file:/local/snarayan/aodsim_test.root')
 )
 process.source.inputCommands = cms.untracked.vstring(
   "keep *",

--- a/TreeFiller/python/utils/makeFatJets.py
+++ b/TreeFiller/python/utils/makeFatJets.py
@@ -289,7 +289,7 @@ def makeFatJets(process,isData,algoLabel,jetRadius,pfCandidates='particleFlow'):
         process,
         labelName='SoftDropPF'+puMethod+rLabel,
         jetSource=cms.InputTag('PFJets'+puMethod+'SoftDrop'+rLabel),
-#        pfCandidates = cms.InputTag('particleFlow'),
+        pfCandidates = cms.InputTag('particleFlow'),
         algo=algoLabel,
         btagInfos = ['None'],
         btagDiscriminators = ['None'],

--- a/TreeFiller/python/utils/makeFatJets.py
+++ b/TreeFiller/python/utils/makeFatJets.py
@@ -127,6 +127,7 @@ def makeFatJets(process,isData,algoLabel,jetRadius,pfCandidates='particleFlow'):
     
     if pfCandidates=='particleFlow':
       puMethod='CHS'
+      pfCandidates = 'pfNoPileUpJMEPFlow' 
     else:
       puMethod='Puppi'
 
@@ -271,7 +272,7 @@ def makeFatJets(process,isData,algoLabel,jetRadius,pfCandidates='particleFlow'):
         jetSource=cms.InputTag('PFJets'+puMethod+rLabel),
         algo=algoLabel,           # needed for jet flavor clustering
         rParam=jetRadius, # needed for jet flavor clustering
-        pfCandidates = cms.InputTag(pfCandidates),
+        pfCandidates = cms.InputTag('particleFlow'),
         pvSource = cms.InputTag(pvSource),
         svSource = cms.InputTag(svSource),
         muSource = cms.InputTag(muSource),
@@ -288,6 +289,7 @@ def makeFatJets(process,isData,algoLabel,jetRadius,pfCandidates='particleFlow'):
         process,
         labelName='SoftDropPF'+puMethod+rLabel,
         jetSource=cms.InputTag('PFJets'+puMethod+'SoftDrop'+rLabel),
+#        pfCandidates = cms.InputTag('particleFlow'),
         algo=algoLabel,
         btagInfos = ['None'],
         btagDiscriminators = ['None'],
@@ -302,7 +304,7 @@ def makeFatJets(process,isData,algoLabel,jetRadius,pfCandidates='particleFlow'):
         jetSource=cms.InputTag('PFJets'+puMethod+'SoftDrop'+rLabel,'SubJets'),
         algo=algoLabel,           # needed for subjet flavor clustering
         rParam=jetRadius, # needed for subjet flavor clustering
-        pfCandidates = cms.InputTag(pfCandidates),
+        pfCandidates = cms.InputTag('particleFlow'),
         pvSource = cms.InputTag(pvSource),
         svSource = cms.InputTag(svSource),
         muSource = cms.InputTag(muSource),


### PR DESCRIPTION
Found two issues:

1) CHS fatjets were being clustered from all PF candidates, without charged hadrons removed. 
2) B-tagging was being done with a pileup-mitigated PF candidate collection (CHS or Puppi), but the taggers are tuned using the full collection.

The correct configurations are now in place.

Sorry about these mistakes. Hope the amount of production that needs to be re-done isn't too big.
